### PR TITLE
feat: add tweet queue scheduler

### DIFF
--- a/api/cron-post.js
+++ b/api/cron-post.js
@@ -1,0 +1,96 @@
+import OAuth from "oauth-1.0a";
+import crypto from "crypto";
+
+const oauth = OAuth({
+  consumer: { key: process.env.CONSUMER_KEY, secret: process.env.CONSUMER_SECRET },
+  signature_method: "HMAC-SHA1",
+  hash_function: (base, key) =>
+    crypto.createHmac("sha1", key).update(base).digest("base64"),
+});
+
+function decodeItem(str) {
+  try {
+    return JSON.parse(Buffer.from(str, "base64").toString());
+  } catch {
+    return null;
+  }
+}
+
+async function rpop() {
+  const r = await fetch(
+    `${process.env.UPSTASH_REDIS_REST_URL}/rpop/queue:tweets`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+      },
+    }
+  );
+  const j = await r.json();
+  if (!r.ok || !j.result) return null;
+  return decodeItem(j.result);
+}
+
+async function lpush(item) {
+  const encoded = Buffer.from(JSON.stringify(item)).toString("base64");
+  await fetch(
+    `${process.env.UPSTASH_REDIS_REST_URL}/lpush/queue:tweets/${encoded}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+      },
+    }
+  );
+}
+
+async function postTweet(text) {
+  const url = "https://api.twitter.com/2/tweets";
+  const token = {
+    key: process.env.ACCESS_TOKEN,
+    secret: process.env.ACCESS_TOKEN_SECRET,
+  };
+  const authHeader = oauth.toHeader(
+    oauth.authorize({ url, method: "POST" }, token)
+  );
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { ...authHeader, "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!r.ok) throw new Error(`tweet_failed_${r.status}`);
+  return r.json();
+}
+
+export default async function handler(req, res) {
+  let processed = 0,
+    requeued = 0,
+    posted = 0;
+  const now = Date.now();
+
+  for (let i = 0; i < 10; i++) {
+    const item = await rpop();
+    if (!item) break;
+    processed++;
+
+    if (item.runAt && new Date(item.runAt).getTime() > now) {
+      await lpush(item);
+      requeued++;
+      break;
+    }
+
+    try {
+      await postTweet(item.text);
+      posted++;
+    } catch (e) {
+      await lpush(item);
+      break;
+    }
+  }
+
+  return res.json({
+    ok: true,
+    processed,
+    requeued,
+    posted,
+    time: new Date().toISOString(),
+  });
+}

--- a/api/queue/add.js
+++ b/api/queue/add.js
@@ -1,0 +1,35 @@
+import crypto from "crypto";
+
+export default async function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "content-type, x-queue-token");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  if (req.method === "OPTIONS") return res.status(200).end();
+  if (req.method !== "POST") return res.status(405).end("Method Not Allowed");
+
+  if (req.headers["x-queue-token"] !== process.env.QUEUE_ADMIN_TOKEN)
+    return res.status(401).json({ error: "unauthorized" });
+
+  const { text, runAt } = req.body || {};
+  if (!text || text.length > 280)
+    return res.status(400).json({ error: "invalid text" });
+
+  const item = {
+    id: crypto.randomUUID(),
+    text,
+    runAt: runAt ? new Date(runAt).toISOString() : null,
+  };
+
+  const encoded = Buffer.from(JSON.stringify(item)).toString("base64");
+  const r = await fetch(
+    `${process.env.UPSTASH_REDIS_REST_URL}/lpush/queue:tweets/${encoded}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+      },
+    }
+  );
+  if (!r.ok) return res.status(500).json({ error: "queue_push_failed" });
+
+  return res.json({ ok: true, enqueued: item });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "crons": [
+    { "path": "/api/cron-post", "schedule": "*/5 * * * *" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add /api/queue/add for enqueueing scheduled tweets in Redis
- add /api/cron-post to post due tweets and requeue others
- configure vercel cron to hit /api/cron-post every 5 minutes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a18b8ecc5c8330ac1d9e5b2ac63b88